### PR TITLE
Update manifest.json - minimum pymodbus version instead of fixed version

### DIFF
--- a/custom_components/sax_battery/manifest.json
+++ b/custom_components/sax_battery/manifest.json
@@ -12,7 +12,7 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/matfroh/sax_battery_ha/issues",
     "requirements": [
-        "pymodbus==3.7.4",
+        "pymodbus>=3.7.4",
         "voluptuous"
     ],
     "version": "0.2.2.4.2"


### PR DESCRIPTION
I had problems updating, because another extension was requiring pymodbus 3.9 and both dependencies where mutually exclusive. Since this extension seems to run fine with higher versions of pymodbus maybe we can change this to a minimum instead of a fixed version requirement?